### PR TITLE
feat: Release new CLI v1.5.2

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -28,7 +28,7 @@ fi
 echo "Bitrise Build Cache is activated in this workspace, configuring the build environment ..."
 
 # download the Bitrise Build Cache CLI
-export BITRISE_BUILD_CACHE_CLI_VERSION="v1.5.0"
+export BITRISE_BUILD_CACHE_CLI_VERSION="v1.5.2"
 curl --retry 5 -m 30 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d $BITRISE_BUILD_CACHE_CLI_VERSION || true
 
 # Fall back to Artifact Registry if the download failed


### PR DESCRIPTION
## Summary
- Update bitrise-build-cache-cli to v1.5.2
- Fix: Detect original CI provider in Build Hub builds instead of always reporting Bitrise

## Test plan
- [ ] CI passes
- [ ] E2E test verifies step runs correctly with new CLI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)